### PR TITLE
add `--iswav` switch to museval cli application

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ museval.eval_mus_dir(
 We provide a commandline wrapper of `eval_mus_dir` by calling the `museval` commandline tool. The following example is equivalent to the code example above:
 
 ```
-museval -p --mus path/to/musdb -o path/to/output_dir path/to/estimate_dir
+museval -p --musdb path/to/musdb -o path/to/output_dir path/to/estimate_dir
 ```
 
 ### Using Docker for Evaluation
@@ -120,7 +120,7 @@ The to run the evaluation inside of the docker, three absolute paths are require
 We just mount these directories into the docker container using the `-v` flags and start the docker instance:
 
 ```
-docker run --rm -v estimatesdir:/est -v musdbdir:/mus -v outputdir:/out faroit/sigsep-mus-eval --mus /mus -o /out /est
+docker run --rm -v estimatesdir:/est -v musdbdir:/mus -v outputdir:/out faroit/sigsep-mus-eval --musdb /mus -o /out /est
 ```
 
 In the line above, replace `estimatesdir`, `musdbdir` and `outputdir` by the absolute paths for your setting.  Please note that docker requires absolute paths so you have to rely on your command line environment to convert relative paths to absolute paths (e.g. by using `$HOME/` on Unix).

--- a/museval/cli.py
+++ b/museval/cli.py
@@ -88,13 +88,18 @@ def museval(inargs=None):
     )
 
     parser.add_argument(
+        '--iswav', help='Read musdb wav instead of stems',
+        action='store_true',
+    )
+
+    parser.add_argument(
         '--version', '-v',
         action='version',
         version='%%(prog)s %s' % util.__version__
     )
 
     args = parser.parse_args(inargs)
-    mus = musdb.DB(root_dir=args.musdb)
+    mus = musdb.DB(root_dir=args.musdb, is_wav=args.iswav)
 
     if not args.o:
         output_dir = args.estimates_dir

--- a/museval/util.py
+++ b/museval/util.py
@@ -1,7 +1,7 @@
 import inspect
 import six
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def has_kwargs(function):

--- a/prepare_tests.sh
+++ b/prepare_tests.sh
@@ -3,4 +3,6 @@
 cd data
 bash fetch.sh
 bash decode.sh
+cp -r data/MUS-STEMS-SAMPLE/ data/EST
+rm -r data/EST/test
 cd ..

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
         name='museval',
 
         # Version
-        version="0.1.0",
+        version="0.1.1",
 
         # Description
         description='Evaluation tools for the SIGSEP MUS database',

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -17,6 +17,14 @@ def mus():
     return musdb.DB(root_dir='data/MUS-STEMS-SAMPLE', is_wav=True)
 
 
+def test_evaluate_mus_dir(mus):
+    museval.eval_mus_dir(
+        dataset=mus,  # instance of musdb
+        estimates_dir='data/EST',  # path to estimate folder
+        output_dir='data/EST_scores',  # set a folder to write eval json files
+    )
+
+
 def test_estimate_and_evaluate(mus):
     # return any number of targets
     with open(json_path) as json_file:


### PR DESCRIPTION
this PR adds the functionality to use the cli app together with a decoded wav version of musdb.

