### PR TITLE
Ensure window slice is an int

### DIFF
--- a/museval/metrics.py
+++ b/museval/metrics.py
@@ -431,9 +431,9 @@ class Framing:
     """helper iterator class to do overlapped windowing"""
     def __init__(self, window, hop, length):
         self.current = 0
-        self.window = window
-        self.hop = hop
-        self.length = length
+        self.window = int(window)
+        self.hop = int(hop)
+        self.length = int(length)
 
     def __iter__(self):
         return self

--- a/museval/metrics.py
+++ b/museval/metrics.py
@@ -431,9 +431,9 @@ class Framing:
     """helper iterator class to do overlapped windowing"""
     def __init__(self, window, hop, length):
         self.current = 0
-        self.window = int(window)
-        self.hop = int(hop)
-        self.length = int(length)
+        self.window = window
+        self.hop = hop
+        self.length = length
 
     def __iter__(self):
         return self
@@ -448,6 +448,8 @@ class Framing:
             stop = min(self.current * self.hop + self.window, self.length)
             if np.isnan(stop) or np.isinf(stop):
                 stop = self.length
+            start = int(np.floor(start))
+            stop = int(np.floor(stop))
             result = slice(start, stop)
             self.current += 1
             return result


### PR DESCRIPTION
This is a proposal for fixing #16.
This is a simple approach that just ensures the values inside the [`Framing`](https://github.com/sigsep/sigsep-mus-eval/blob/master/museval/metrics.py#L430-L464) object are integers. Then `slice` will not again complain.
I didn't checked what will happen if you specify a non-integer window size -- which gets rounded inside `Framing` -- and have a slight mismatch between signal length and window length in the end.