### PR TITLE
bugfix of JSON to DataFrame conversion

### DIFF
--- a/museval/aggregate.py
+++ b/museval/aggregate.py
@@ -408,14 +408,11 @@ def json2df(json_string, track_name):
         ['frames'],
         ['name']
     )
+    
+    df.columns = [col.replace('metrics.', '') for col in df.columns]
+    
     df = pd.melt(
-        pd.concat(
-            [
-                df.drop(['metrics'], axis=1),
-                df['metrics'].apply(pd.Series)
-            ],
-            axis=1
-        ),
+        df,
         var_name='metric',
         value_name='score',
         id_vars=['time', 'name'],


### PR DESCRIPTION
Line 414: `df.drop(['metrics'], axis=1)`, gave me `KeyError: "['metrics'] not found in axis"` when I tried to use the master version of museval.

This quick fix should correctly rename the columns and convert the DataFrame into a format that is usable for subsequent museval operations.