### PR TITLE
fix: add LICENSE to distribution packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include musdb/configs *.yaml
+include LICENSE


### PR DESCRIPTION
As I am currently adding this package on `conda-forge`, I need to have the LICENSE file packaged along with built `sdist`.