### PR TITLE
Update pandas usage of json_normalize

### DIFF
--- a/museval/aggregate.py
+++ b/museval/aggregate.py
@@ -1,6 +1,5 @@
 import pandas
 from pathlib import Path
-from pandas.io.json import json_normalize
 import pandas as pd
 import simplejson
 import argparse
@@ -403,7 +402,7 @@ def json2df(json_string, track_name):
     track_name : str
     """
 
-    df = json_normalize(
+    df = pd.json_normalize(
         json_string['targets'],
         ['frames'],
         ['name']

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         # computations stack
         install_requires=[
             'musdb>=0.3.0',
-            'pandas>=0.25.0',
+            'pandas>=1.0.1',
             'numpy',
             'scipy',
             'simplejson',


### PR DESCRIPTION
This is to fix the following future warning now thrown by pandas 1.0.1:
`FutureWarning: pandas.io.json.json_normalize is deprecated, use pandas.json_normalize instead ['name']`