### PR TITLE
Fixes for the new versions of pandas and simplejson

### DIFF
--- a/museval/aggregate.py
+++ b/museval/aggregate.py
@@ -180,9 +180,9 @@ class EvalStore(object):
             track store object
         """
         if isinstance(track, TrackStore):
-            self.df = self.df.append(track.df, ignore_index=True)
+            self.df = pd.concat([self.df, track.df], ignore_index=True)
         else:
-            self.df = self.df.append(track, ignore_index=True)
+            self.df = pd.concat([self.df, track], ignore_index=True)
 
     def add_eval_dir(self, path):
         """add precomputed json folder to dataframe
@@ -299,7 +299,7 @@ class MethodStore(object):
         raw_data = urlopen('https://github.com/sigsep/sigsep-mus-2018-analysis/releases/download/v1.0.0/sisec18_mus.pandas')
         print('Done!')
         df_sisec = pd.read_pickle(raw_data, compression=None)
-        self.df = self.df.append(df_sisec, ignore_index=True)
+        self.df = pd.concat([self.df, df_sisec], ignore_index=True)
 
     def add_eval_dir(self, path):
         """add precomputed json folder to dataframe.
@@ -336,7 +336,7 @@ class MethodStore(object):
         """
         df_to_add = method.df
         df_to_add['method'] = name
-        self.df = self.df.append(df_to_add, ignore_index=True)
+        self.df = pd.concat([self.df, df_to_add], ignore_index=True)
     
     def agg_frames_scores(self):
         """aggregates frames scores

--- a/museval/aggregate.py
+++ b/museval/aggregate.py
@@ -110,7 +110,7 @@ class TrackStore(object):
             pandas dataframe object of track scores
         """
         # encode and decode to json first
-        return json2df(simplejson.loads(self.json), self.track_name)
+        return json2df(simplejson.loads(self.json, allow_nan=True), self.track_name)
 
     def __repr__(self):
         """Print the frames_aggregated values instead of all frames
@@ -197,7 +197,7 @@ class EvalStore(object):
             json_paths = p.glob('test/**/*.json')
             for json_path in json_paths:
                 with open(json_path) as json_file:
-                    json_string = simplejson.loads(json_file.read())
+                    json_string = simplejson.loads(json_file.read(), allow_nan=True)
                 track_df = json2df(json_string, json_path.stem)
                 self.add_track(track_df)
 
@@ -317,7 +317,7 @@ class MethodStore(object):
             json_paths = p.glob('test/**/*.json')
             for json_path in json_paths:
                 with open(json_path) as json_file:
-                    json_string = simplejson.loads(json_file.read())
+                    json_string = simplejson.loads(json_file.read(), allow_nan=True)
                 track_df = json2df(json_string, json_path.stem)
                 method.add_track(track_df)
         self.add_evalstore(method, p.stem)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             'pandas>=1.0.1',
             'numpy',
             'scipy',
-            'simplejson',
+            'simplejson>=3.19.0',
             'soundfile',
             'jsonschema'
         ],


### PR DESCRIPTION
Hello!

I've run through some errors when using `museval` with the newer versions of `pandas` and `simplejson`, but I think I've been able to fix them:

1. `DataFrame.append` and `Series.append` were flagged as deprecated in `pandas 1.4.0` and finally removed in `pandas 2.0.0.` I've just replaced them with `pandas.concat` as suggested in [the deprecation note](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append).
2. Since version  v3.19.0, `simplejson.load` doesn't allow NaN values, so the code crashes. I've just added `allow_nan=True` when calling the function, but this is not available in order versions of `simplejson`, so I've added v3.19.0 as the minimum version of `simplejson` in the dependencies of `museval`.

This is my first time working with `museval` (and I don't really have much experience working with `pandas` and `simplejson`) so maybe the fixes are not optimal or those functions are also used in other scripts apart from `museval/aggregate.py`.

Best regards,
David