### PR TITLE
[O] Better error message

### DIFF
--- a/museval/aggregate.py
+++ b/museval/aggregate.py
@@ -253,6 +253,9 @@ class EvalStore(object):
         self.df.to_pickle(path)
 
     def __repr__(self):
+        # Check if df is not empty
+        assert not self.df.empty, "DataFrame is empty. Please add tracks first."
+
         targets = self.df["target"].unique()
         out = "Aggrated Scores ({} over frames, {} over tracks)\n".format(
             self.frames_agg, self.tracks_agg


### PR DESCRIPTION
Instead of a random `KeyError: 'target'`, print an error message that's actually useful.